### PR TITLE
Fixed ObjectDisposedException when request content has been disposed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- `ObjectDisposedException` that can happen on complex interactions involving multiple requests/responses that are being disposed.
+
 ### Security
 
 ## 1.1.0

--- a/HttpRecorder.Tests/HttpClientFactoryTests.cs
+++ b/HttpRecorder.Tests/HttpClientFactoryTests.cs
@@ -36,5 +36,33 @@ namespace HttpRecorder.Tests
             var response = await client.GetAsync(ApiController.JsonUri);
             response.EnsureSuccessStatusCode();
         }
+
+        [Fact]
+        public async Task ItShouldWorkWithComplexInteractionsInvolvingDisposedContent()
+        {
+            var services = new ServiceCollection();
+            services
+                .AddHttpClient(
+                    "TheClient",
+                    options =>
+                    {
+                        options.BaseAddress = _fixture.ServerUri;
+                    })
+                .AddHttpRecorder(nameof(ItShouldWorkWithHttpClientFactory), HttpRecorderMode.Record);
+
+            var client = services.BuildServiceProvider().GetRequiredService<IHttpClientFactory>().CreateClient("TheClient");
+
+            var formContent = new FormUrlEncodedContent(new[]
+                {
+                    new KeyValuePair<string, string>("name", "TheName"),
+                });
+
+            var response = await client.PostAsync(ApiController.FormDataUri, formContent);
+            response.EnsureSuccessStatusCode();
+            response.Dispose();
+
+            response = await client.PostAsync(ApiController.FormDataUri, formContent);
+            response.EnsureSuccessStatusCode();
+        }
     }
 }

--- a/HttpRecorder/HttpRecorderDelegatingHandler.cs
+++ b/HttpRecorder/HttpRecorderDelegatingHandler.cs
@@ -141,7 +141,7 @@ namespace HttpRecorder
                     _interaction == null ? new[] { newInteractionMessage } : _interaction.Messages.Append(newInteractionMessage));
 
                 _interaction = await _anonymizer.Anonymize(_interaction, cancellationToken);
-                await _repository.StoreAsync(_interaction, cancellationToken);
+                _interaction = await _repository.StoreAsync(_interaction, cancellationToken);
 
                 return await PostProcessResponse(newInteractionMessage.Response);
             }

--- a/HttpRecorder/Repositories/HAR/HttpArchiveInteractionRepository.cs
+++ b/HttpRecorder/Repositories/HAR/HttpArchiveInteractionRepository.cs
@@ -49,7 +49,7 @@ namespace HttpRecorder.Repositories.HAR
         }
 
         /// <inheritdoc />
-        public Task StoreAsync(Interaction interaction, CancellationToken cancellationToken = default)
+        public Task<Interaction> StoreAsync(Interaction interaction, CancellationToken cancellationToken = default)
         {
             if (interaction == null)
             {
@@ -67,7 +67,7 @@ namespace HttpRecorder.Repositories.HAR
 
                 File.WriteAllText(GetFilePath(interaction.Name), JsonConvert.SerializeObject(archive, Formatting.Indented, _jsonSettings));
 
-                return Task.CompletedTask;
+                return Task.FromResult(archive.ToInteraction(interaction.Name));
             }
             catch (Exception ex) when ((ex is IOException) || (ex is JsonException))
             {

--- a/HttpRecorder/Repositories/IInteractionRepository.cs
+++ b/HttpRecorder/Repositories/IInteractionRepository.cs
@@ -30,7 +30,7 @@ namespace HttpRecorder.Repositories
         /// </summary>
         /// <param name="interaction">The <see cref="Interaction"/> to store.</param>
         /// <param name="cancellationToken">A cancellation token to cancel operation.</param>
-        /// <returns>The <see cref="Task"/>.</returns>
-        Task StoreAsync(Interaction interaction, CancellationToken cancellationToken);
+        /// <returns>The persisted <see cref="Interaction"/>.</returns>
+        Task<Interaction> StoreAsync(Interaction interaction, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
## Proposed Changes
- Bug fix

## What is the current behavior?
- Can get an ObjectDisposedException when interactions involve multiple requests and responses and responses are being disposed aggressively

## What is the new behavior?
- NO more exceptions - the fix consisted in returning the de-serialized interaction instead of the original one that still referenced the original disposed content.


## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue

