### PR TITLE
Fix: Exception when using RulesMatcher.ByContent on different body sizes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - `ObjectDisposedException` that can happen on complex interactions involving multiple requests/responses that are being disposed.
+- `ArgumentException`: *Object is not a array with the same number of elements as the array to compare it* to when comparing requests by content with different body sizes.
 
 ### Security
 

--- a/HttpRecorder.Tests/Matchers/RulesMatcherUnitTests.cs
+++ b/HttpRecorder.Tests/Matchers/RulesMatcherUnitTests.cs
@@ -106,9 +106,29 @@ namespace HttpRecorder.Tests.Matchers
         }
 
         [Fact]
-        public void ItShouldMatchOnceByContent()
+        public void ItShouldMatchOnceByContentWithSameSize()
         {
             var firstContent = new ByteArrayContent(new byte[] { 0, 1, 2, 3 });
+            var secondContent = new ByteArrayContent(new byte[] { 3, 2, 1, 0 });
+            var interaction = BuildInteraction(
+                new HttpRequestMessage(),
+                new HttpRequestMessage { Content = firstContent },
+                new HttpRequestMessage { Content = secondContent });
+            var request = new HttpRequestMessage { Content = secondContent };
+
+            var matcher = RulesMatcher.MatchOnce
+                .ByContent();
+
+            var result = matcher.Match(request, interaction);
+
+            result.Should().NotBeNull();
+            result.Response.RequestMessage.Content.Should().BeEquivalentTo(secondContent);
+        }
+
+        [Fact]
+        public void ItShouldMatchOnceByContentWithDifferentSizes()
+        {
+            var firstContent = new ByteArrayContent(new byte[] { 0, 1 });
             var secondContent = new ByteArrayContent(new byte[] { 3, 2, 1, 0 });
             var interaction = BuildInteraction(
                 new HttpRequestMessage(),


### PR DESCRIPTION
## Proposed Changes
- Bug fix

## What is the current behavior?
Getting `ArgumentException`: *Object is not a array with the same number of elements as the array to compare it* to when comparing requests by content with different body sizes.

## What is the new behavior?
Comparison is now properly done between binary arrays by checking for null conditions and length before using the `StructuralComparer`.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

