### PR TITLE
Changed from NewtonSoft to System.Text.Json.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - [BREAKING]: Removed the `innerHandler` parameter in the `RequestsSignatureDelegatingHandler` constructor; you must now use the `InnerHandler` property.
+- [BREAKING]: Moved from NewtonSoft to System.Text.Json serialization.
 
 ### Deprecated
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/GlobalSuppressions.cs
+++ b/GlobalSuppressions.cs
@@ -9,4 +9,5 @@
 [assembly: SuppressMessage("Globalization", "CA1303:Do not pass literals as localized parameters", Justification = "Localization is not in scope.")]
 [assembly: SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient has some questionable Dispose patterns.")]
 [assembly: SuppressMessage("Reliability", "CA2007:Do not directly await a Task", Justification = "Not needed systematically.")]
+[assembly: SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Conflicts with Serialization.")]
 [assembly: SuppressMessage("Usage", "CA2234:Pass system uri objects instead of strings", Justification = "String is fine - Uri class is sometime cumbersome.")]

--- a/HttpRecorder/HttpRecorder.csproj
+++ b/HttpRecorder/HttpRecorder.csproj
@@ -16,9 +16,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 
 </Project>

--- a/HttpRecorder/Matchers/RulesMatcher.cs
+++ b/HttpRecorder/Matchers/RulesMatcher.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace HttpRecorder.Matchers
 {
@@ -158,18 +158,18 @@ namespace HttpRecorder.Matchers
         /// </summary>
         /// <typeparam name="T">The json object type.</typeparam>
         /// <param name="equalityComparer"><see cref="IEqualityComparer{T}"/> to use. Defaults to <see cref="EqualityComparer{T}.Default"/>.</param>
-        /// <param name="jsonSerializerSettings">The <see cref="JsonSerializerSettings"/> to use.</param>
+        /// <param name="jsonSerializerOptions">The <see cref="JsonSerializerOptions"/> to use.</param>
         /// <returns>A new <see cref="RulesMatcher"/>.</returns>
         public RulesMatcher ByJsonContent<T>(
             IEqualityComparer<T> equalityComparer = null,
-            JsonSerializerSettings jsonSerializerSettings = null)
+            JsonSerializerOptions jsonSerializerOptions = null)
             => By((request, message) =>
             {
                 var requestContent = request.Content?.ReadAsStringAsync()?.Result;
-                var requestJson = !string.IsNullOrEmpty(requestContent) ? JsonConvert.DeserializeObject<T>(requestContent, jsonSerializerSettings) : default(T);
+                var requestJson = !string.IsNullOrEmpty(requestContent) ? JsonSerializer.Deserialize<T>(requestContent, jsonSerializerOptions) : default(T);
 
                 var interactionContent = message.Response.RequestMessage.Content?.ReadAsStringAsync()?.Result;
-                var interactionJson = !string.IsNullOrEmpty(interactionContent) ? JsonConvert.DeserializeObject<T>(interactionContent, jsonSerializerSettings) : default(T);
+                var interactionJson = !string.IsNullOrEmpty(interactionContent) ? JsonSerializer.Deserialize<T>(interactionContent, jsonSerializerOptions) : default(T);
 
                 if (equalityComparer == null)
                 {

--- a/HttpRecorder/Repositories/HAR/HttpArchiveInteractionRepository.cs
+++ b/HttpRecorder/Repositories/HAR/HttpArchiveInteractionRepository.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 
 namespace HttpRecorder.Repositories.HAR
 {
@@ -18,11 +17,12 @@ namespace HttpRecorder.Repositories.HAR
     /// </remarks>
     public class HttpArchiveInteractionRepository : IInteractionRepository
     {
-        private static readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings
+        private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions
         {
-            ContractResolver = new CamelCasePropertyNamesContractResolver(),
-            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-            NullValueHandling = NullValueHandling.Ignore,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            IgnoreNullValues = true,
+            WriteIndented = true,
         };
 
         /// <inheritdoc />
@@ -36,9 +36,9 @@ namespace HttpRecorder.Repositories.HAR
         {
             try
             {
-                var archive = JsonConvert.DeserializeObject<HttpArchive>(
+                var archive = JsonSerializer.Deserialize<HttpArchive>(
                 File.ReadAllText(GetFilePath(interactionName), Encoding.UTF8),
-                _jsonSettings);
+                _jsonOptions);
 
                 return Task.FromResult(archive.ToInteraction(interactionName));
             }
@@ -65,7 +65,7 @@ namespace HttpRecorder.Repositories.HAR
                     Directory.CreateDirectory(archiveDirectory);
                 }
 
-                File.WriteAllText(GetFilePath(interaction.Name), JsonConvert.SerializeObject(archive, Formatting.Indented, _jsonSettings));
+                File.WriteAllText(GetFilePath(interaction.Name), JsonSerializer.Serialize(archive, _jsonOptions));
 
                 return Task.FromResult(archive.ToInteraction(interaction.Name));
             }

--- a/HttpRecorder/Repositories/HAR/Log.cs
+++ b/HttpRecorder/Repositories/HAR/Log.cs
@@ -19,8 +19,8 @@ namespace HttpRecorder.Repositories.HAR
         public Creator Creator { get; set; } = new Creator();
 
         /// <summary>
-        /// Gets the list of <see cref="Entry"/>.
+        /// Gets or sets the list of <see cref="Entry"/>.
         /// </summary>
-        public IList<Entry> Entries { get; private set; } = new List<Entry>();
+        public List<Entry> Entries { get; set; } = new List<Entry>();
     }
 }

--- a/HttpRecorder/Repositories/HAR/Message.cs
+++ b/HttpRecorder/Repositories/HAR/Message.cs
@@ -20,14 +20,14 @@ namespace HttpRecorder.Repositories.HAR
         public string HttpVersion { get; set; }
 
         /// <summary>
-        /// Gets the list of cookie objects. NOT SUPPORTED.
+        /// Gets or sets the list of cookie objects. NOT SUPPORTED.
         /// </summary>
-        public IList<object> Cookies { get; private set; } = new List<object>();
+        public List<object> Cookies { get; set; } = new List<object>();
 
         /// <summary>
-        /// Gets the list of <see cref="Header"/>.
+        /// Gets or sets the list of <see cref="Header"/>.
         /// </summary>
-        public IList<Header> Headers { get; private set; } = new List<Header>();
+        public List<Header> Headers { get; set; } = new List<Header>();
 
         /// <summary>
         /// Gets or sets the total number of bytes from the start of the HTTP request message until (and including) the double CRLF before the body.

--- a/HttpRecorder/Repositories/HAR/PostData.cs
+++ b/HttpRecorder/Repositories/HAR/PostData.cs
@@ -49,9 +49,9 @@ namespace HttpRecorder.Repositories.HAR
         public string MimeType { get; set; }
 
         /// <summary>
-        /// Gets the list of <see cref="PostedParam"/>.
+        /// Gets or sets the list of <see cref="PostedParam"/>.
         /// </summary>
-        public IList<PostedParam> Params { get; private set; } = new List<PostedParam>();
+        public List<PostedParam> Params { get; set; } = new List<PostedParam>();
 
         /// <summary>
         /// Gets or sets plain text posted data.

--- a/HttpRecorder/Repositories/HAR/Request.cs
+++ b/HttpRecorder/Repositories/HAR/Request.cs
@@ -69,9 +69,9 @@ namespace HttpRecorder.Repositories.HAR
         public Uri Url { get; set; }
 
         /// <summary>
-        /// Gets the list of <see cref="QueryParameter"/> parameters.
+        /// Gets or sets the list of <see cref="QueryParameter"/> parameters.
         /// </summary>
-        public IList<QueryParameter> QueryString { get; private set; } = new List<QueryParameter>();
+        public List<QueryParameter> QueryString { get; set; } = new List<QueryParameter>();
 
         /// <summary>
         /// Gets or sets the <see cref="PostData"/>.


### PR DESCRIPTION
## Proposed Changes
 - Feature

## What is the current behavior?
Uses NewtonSoft.Json for serialization.


## What is the new behavior?
Uses System.Text.Json for serialization.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [x] Automated Unit / Integration tests for the changes have been added/updated
- [ ] Contains **NO** breaking changes
- [x] Updated the Changelog
- [ ] Associated with an issue

This is breaking as some part of the API expose the serializer settings.
Also, may break the existing recording (hopefully not).

