### PR TITLE
Simplify configuration for generating the documentation file

### DIFF
--- a/HttpRecorder/HttpRecorder.csproj
+++ b/HttpRecorder/HttpRecorder.csproj
@@ -5,14 +5,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\HttpRecorder.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\HttpRecorder.xml</DocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
See the [MSBuild reference for .NET SDK projects](https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#generatedocumentationfile)

> The `GenerateDocumentationFile` property controls whether the compiler generates an XML documentation file for your library. If you set this property to `true` and you don't specify a file name via the DocumentationFile property, the generated XML file is placed in the same output directory as your assembly and has the same file name (but with an _.xml_ extension).