### PR TITLE
Fix the redirectURL casing in the HAR response

### DIFF
--- a/HttpRecorder/Repositories/HAR/Response.cs
+++ b/HttpRecorder/Repositories/HAR/Response.cs
@@ -72,7 +72,12 @@ namespace HttpRecorder.Repositories.HAR
         /// <summary>
         /// Gets or sets the redirection target URL from the Location response header.
         /// </summary>
+        /// <remarks>
+        /// This property must have the <c>URL</c> part in uppercase to observe the <a href="https://w3c.github.io/web-performance/specs/HAR/Overview.html">HAR specification</a>.
+        /// Renaming this property to <c>RedirectUrl</c> could break tools implementing the HAR specification.
+        /// </remarks>
         [SuppressMessage("Design", "CA1056:Uri properties should not be strings", Justification = "Conform to specification that can include empty strings.")]
+        [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Conform to specification requires URL to be uppercased.")]
         public string RedirectURL { get; set; } = string.Empty;
 
         /// <summary>

--- a/HttpRecorder/Repositories/HAR/Response.cs
+++ b/HttpRecorder/Repositories/HAR/Response.cs
@@ -34,7 +34,7 @@ namespace HttpRecorder.Repositories.HAR
             StatusText = response.ReasonPhrase;
             if (response.Headers.Location != null)
             {
-                RedirectUrl = response.Headers.Location.ToString();
+                RedirectURL = response.Headers.Location.ToString();
             }
 
             foreach (var header in response.Headers)
@@ -73,7 +73,7 @@ namespace HttpRecorder.Repositories.HAR
         /// Gets or sets the redirection target URL from the Location response header.
         /// </summary>
         [SuppressMessage("Design", "CA1056:Uri properties should not be strings", Justification = "Conform to specification that can include empty strings.")]
-        public string RedirectUrl { get; set; } = string.Empty;
+        public string RedirectURL { get; set; } = string.Empty;
 
         /// <summary>
         /// Returns a <see cref="HttpResponseMessage"/>.


### PR DESCRIPTION
According to the standard it must be `redirectURL` and not `redirectUrl`.